### PR TITLE
Added a `restarted` decorator flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ async function start (opts) {
   let listening = false
   let stopped = false
   const res = {
-    app: await (spinUpFastify(opts, serverWrapper, restart).ready()),
+    app: await (spinUpFastify(opts, serverWrapper, restart, true).ready()),
     restart,
     get address () {
       if (!listening) {
@@ -55,6 +55,7 @@ async function start (opts) {
       old.server.removeListener('clientError', listener)
     }
     res.app = newApp
+
     await old.close()
   }
 
@@ -73,7 +74,7 @@ async function start (opts) {
   }
 }
 
-function spinUpFastify (opts, serverWrapper, restart) {
+function spinUpFastify (opts, serverWrapper, restart, isStart = false) {
   const server = serverWrapper.server
   const _opts = Object.assign({}, opts)
   _opts.serverFactory = function (handler) {
@@ -83,7 +84,7 @@ function spinUpFastify (opts, serverWrapper, restart) {
   const app = Fastify(_opts)
 
   app.decorate('restart', restart)
-
+  app.decorate('restarted', !isStart)
   app.register(opts.app, opts)
 
   return app

--- a/test/test.js
+++ b/test/test.js
@@ -17,7 +17,7 @@ setGlobalDispatcher(new Agent({
 }))
 
 test('restart fastify', async ({ pass, teardown, plan, same, equal }) => {
-  plan(9)
+  plan(11)
 
   const _opts = {
     port: 0,
@@ -33,6 +33,9 @@ test('restart fastify', async ({ pass, teardown, plan, same, equal }) => {
   }
 
   const server = await start(_opts)
+
+  same(server.app.restarted, false)
+
   const { stop, restart, listen } = server
   teardown(stop)
 
@@ -48,6 +51,7 @@ test('restart fastify', async ({ pass, teardown, plan, same, equal }) => {
   }
 
   await restart()
+  same(server.app.restarted, true)
 
   {
     const res = await request(`http://127.0.0.1:${port}`)


### PR DESCRIPTION
Added a `restarted` decorator flag

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
