### PR TITLE
Fix: Proxy should always return factory wrapped version of app

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ async function restartable (factory, opts, fastify = defaultFastify) {
   const proxy = { then: undefined }
 
   let app = await factory((opts) => createApplication(opts, false), opts)
+  Object.setPrototypeOf(proxy, app)
+
   const server = wrapServer(app.server)
 
   let newHandler = null
@@ -90,10 +92,6 @@ async function restartable (factory, opts, fastify = defaultFastify) {
     }
 
     const app = fastify({ ...newOpts, serverFactory })
-
-    if (!isRestarted) {
-      Object.setPrototypeOf(proxy, app)
-    }
 
     app.decorate('restart', debounceRestart)
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,6 +4,7 @@ const { join } = require('path')
 const { once } = require('events')
 const { readFile } = require('fs/promises')
 const http2 = require('http2')
+const fastify = require('fastify')
 
 const t = require('tap')
 const split = require('split2')
@@ -742,4 +743,20 @@ test('should restart an app before listening', async (t) => {
 
   await app.close()
   t.ok(!app.server.listening)
+})
+
+test('should always proxy to the factory wrapped version of app', async (t) => {
+  async function userProvidedFactory () {
+    const app = fastify()
+
+    app.userProvided = true
+
+    return app
+  }
+
+  const proxy = await restartable(userProvidedFactory, {
+    keepAliveTimeout: 1
+  })
+
+  t.same(proxy.userProvided, true)
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Before this change, when the server was first booted, the proxy, which is returned from `restartable` was pointing to a copy of app that's returned from `fastify({ ...newOpts, serverFactory })`, but from `await factory(createApplication, opts, restartOptions)` (with the user provided factory wrapper) after restarts.

On first boot `app` is a reference to what was returned from the `fastify` wrapper: 

https://github.com/fastify/restartable/blob/0b02b0d46c44ba6f192e419bc2e2ecb93a086bfc/index.js#L92
https://github.com/fastify/restartable/blob/0b02b0d46c44ba6f192e419bc2e2ecb93a086bfc/index.js#L95

On reboot `newApp` is a reference to the output of the users `factory` wrapper:

https://github.com/fastify/restartable/blob/0b02b0d46c44ba6f192e419bc2e2ecb93a086bfc/index.js#L27
https://github.com/fastify/restartable/blob/0b02b0d46c44ba6f192e419bc2e2ecb93a086bfc/index.js#L50

It was not possible to access the copy of app wrapped by `factory`, unless the server was restarted immediately after fist boot.

With this proposed change, the proxy always points to the latest copy of the app wrapped by the users factory.

Fixes #45 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [-] tests and/or benchmarks are included
- [-] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
