### PR TITLE
fix: expose closingRestartable into types

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,16 @@ async function createApp (fastify, opts) {
     await app.restart()
     return { status: 'ok' }
   })
-
+  
+  app.addHook('onClose', async () => {
+    if(!app.closingRestartable) {
+      console.log('closing the app because of restart')
+    }
+    else{
+      console.log('closing the app because server is stopping')
+    }
+  })
+  
   return app
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,6 +8,7 @@ declare module 'fastify' {
     addPreRestartHook: (fn: RestartHook) => void,
     addOnRestartHook: (fn: RestartHook) => void,
     restarted: boolean
+    closingRestartable: boolean
   }
 }
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -26,6 +26,7 @@ expectType<ApplicationFactory>(createApplication)
   const app = await restartable(createApplication)
   expectType<FastifyInstance>(app)
   expectType<boolean>(app.restarted)
+  expectType<boolean>(app.closingRestartable)
   expectType<(restartOpts?: unknown) => Promise<void>>(app.restart)
 }
 
@@ -33,6 +34,7 @@ expectType<ApplicationFactory>(createApplication)
   const app = await restartable(createApplication, { logger: true })
   expectType<FastifyInstance>(app)
   expectType<boolean>(app.restarted)
+  expectType<boolean>(app.closingRestartable)
   expectType<(restartOpts?: unknown) => Promise<void>>(app.restart)
 }
 
@@ -40,6 +42,7 @@ expectType<ApplicationFactory>(createApplication)
   const app = await restartable(createApplication, { logger: true }, fastify)
   expectType<FastifyInstance>(app)
   expectType<boolean>(app.restarted)
+  expectType<boolean>(app.closingRestartable)
   expectType<(restartOpts?: unknown) => Promise<void>>(app.restart)
 }
 


### PR DESCRIPTION
It simply exposes the closingRestartable decorator in the types and adds it to the example ;-)
