### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const http = require('http')
-const https = require('https')
+const http = require('node:http')
+const https = require('node:https')
 
 const { FST_ERR_HTTP2_INVALID_VERSION } = require('fastify').errorCodes
 
@@ -35,7 +35,7 @@ function getServerInstance (options, httpHandler) {
 
 function http2 () {
   try {
-    return require('http2')
+    return require('node:http2')
   } catch (err) {
     // istanbul ignore next
     throw new FST_ERR_HTTP2_INVALID_VERSION()

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const { join } = require('path')
-const { once } = require('events')
-const { readFile } = require('fs/promises')
-const http2 = require('http2')
+const { join } = require('node:path')
+const { once } = require('node:events')
+const { readFile } = require('node:fs/promises')
+const http2 = require('node:http2')
 
 const t = require('tap')
 const split = require('split2')


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
