### PR TITLE
Restartable generic

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,19 +1,113 @@
-import { fastify, FastifyInstance, FastifyServerOptions } from 'fastify'
+import { fastify, FastifyInstance } from "fastify";
 
-export type RestartHook = (instance: FastifyInstance, restartOpts?: unknown) => Promise<unknown>
+import type {
+  FastifyBaseLogger,
+  FastifyHttp2Options,
+  FastifyHttp2SecureOptions,
+  FastifyHttpOptions,
+  FastifyHttpsOptions,
+  FastifyServerOptions,
+  FastifyTypeProvider,
+  FastifyTypeProviderDefault,
+  RawReplyDefaultExpression,
+  RawRequestDefaultExpression,
+  RawServerBase,
+  RawServerDefault,
+} from "fastify";
+import * as http from "http";
+import * as http2 from "http2";
+import * as https from "https";
 
-declare module 'fastify' {
+export type RestartHook = (
+  instance: FastifyInstance,
+  restartOpts?: unknown
+) => Promise<unknown>;
+
+declare module "fastify" {
   interface FastifyInstance {
-    restart: (restartOpts?: unknown) => Promise<void>,
-    addPreRestartHook: (fn: RestartHook) => void,
-    addOnRestartHook: (fn: RestartHook) => void,
-    restarted: boolean
-    closingRestartable: boolean
+    restart: (restartOpts?: unknown) => Promise<void>;
+    addPreRestartHook: (fn: RestartHook) => void;
+    addOnRestartHook: (fn: RestartHook) => void;
+    restarted: boolean;
+    closingRestartable: boolean;
   }
 }
 
 type Fastify = typeof fastify;
 
-export type ApplicationFactory = (fastify: Fastify, opts: FastifyServerOptions, restartOpts?: unknown) => Promise<FastifyInstance>
+export type ApplicationFactory<
+  Server extends
+    | RawServerBase
+    | http.Server
+    | https.Server
+    | http2.Http2Server
+    | http2.Http2SecureServer = RawServerDefault,
+  Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
+  Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
+> = (
+  fastify: Fastify,
+  opts: Server extends infer S
+    ? S extends http2.Http2SecureServer
+      ? FastifyHttp2SecureOptions<S, Logger>
+      : S extends http2.Http2Server
+      ? FastifyHttp2Options<S, Logger>
+      : S extends https.Server
+      ? FastifyHttpsOptions<S, Logger>
+      : S extends http.Server
+      ? FastifyHttpOptions<S, Logger>
+      : FastifyServerOptions<Server>
+    : FastifyServerOptions<Server>,
+  restartOpts?: unknown
+) => Promise<FastifyInstance<Server, Request, Reply, Logger, TypeProvider>>;
 
-export declare function restartable(factory: ApplicationFactory, opts?: FastifyServerOptions, fastify?: Fastify): Promise<FastifyInstance>
+// These overloads follow the same overloads for the fastify factory
+
+export declare function restartable<
+  Server extends http2.Http2SecureServer,
+  Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
+  Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
+>(
+  factory: ApplicationFactory<Server, Request, Reply, Logger, TypeProvider>,
+  opts?: FastifyHttp2SecureOptions<Server, Logger>,
+  fastify?: Fastify
+): Promise<FastifyInstance<Server, Request, Reply, Logger, TypeProvider>>;
+
+export declare function restartable<
+  Server extends http2.Http2Server,
+  Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
+  Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
+>(
+  factory: ApplicationFactory<Server, Request, Reply, Logger, TypeProvider>,
+  opts?: FastifyHttp2Options<Server, Logger>,
+  fastify?: Fastify
+): Promise<FastifyInstance<Server, Request, Reply, Logger, TypeProvider>>;
+
+export declare function restartable<
+  Server extends https.Server,
+  Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
+  Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
+>(
+  factory: ApplicationFactory<Server, Request, Reply, Logger, TypeProvider>,
+  opts?: FastifyHttpsOptions<Server, Logger>,
+  fastify?: Fastify
+): Promise<FastifyInstance<Server, Request, Reply, Logger, TypeProvider>>;
+
+export declare function restartable<
+  Server extends http.Server,
+  Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
+  Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
+>(
+  factory: ApplicationFactory<Server, Request, Reply, Logger, TypeProvider>,
+  opts?: FastifyHttpOptions<Server, Logger>,
+  fastify?: Fastify
+): Promise<FastifyInstance<Server, Request, Reply, Logger, TypeProvider>>;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,24 +1,24 @@
-import { fastify, FastifyInstance, FastifyServerOptions } from "fastify";
-import { expectAssignable, expectType } from "tsd";
-import { restartable, ApplicationFactory } from "./index";
-import type { Http2Server } from "http2";
+import { fastify, FastifyInstance, FastifyServerOptions } from 'fastify'
+import { expectAssignable, expectType } from 'tsd'
+import { restartable, ApplicationFactory } from './index'
+import type { Http2Server } from "http2"
 
-type Fastify = typeof fastify;
+type Fastify = typeof fastify
 
-async function createApplication(
+async function createApplication (
   fastify: Fastify,
   opts: FastifyServerOptions,
   restartOpts?: unknown
 ): Promise<FastifyInstance> {
-  const app = fastify(opts);
+  const app = fastify(opts)
 
-  expectAssignable<FastifyInstance>(app);
-  expectAssignable<unknown>(restartOpts);
+  expectAssignable<FastifyInstance>(app)
+  expectAssignable<unknown>(restartOpts)
 
-  expectType<boolean>(app.restarted);
-  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart);
+  expectType<boolean>(app.restarted)
+  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart)
 
-  return app;
+  return app
 }
 
 // This currently fails with:
@@ -28,30 +28,30 @@ async function createApplication(
 // opts: FastifyServerOptions, restartOpts?: unknown)
 // => Promise<FastifyInstance<RawServerDefault, IncomingMessage, ServerResponse<...>,
 // FastifyBaseLogger, FastifyTypeProviderDefault>>
-// expectType<ApplicationFactory>(createApplication);
+// expectType<ApplicationFactory>(createApplication)
 
 {
-  const app = await restartable(createApplication);
-  expectType<FastifyInstance>(app);
-  expectType<boolean>(app.restarted);
-  expectType<boolean>(app.closingRestartable);
-  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart);
+  const app = await restartable(createApplication)
+  expectType<FastifyInstance>(app)
+  expectType<boolean>(app.restarted)
+  expectType<boolean>(app.closingRestartable)
+  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart)
 }
 
 {
-  const app = await restartable(createApplication, { logger: true });
-  expectType<FastifyInstance>(app);
-  expectType<boolean>(app.restarted);
-  expectType<boolean>(app.closingRestartable);
-  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart);
+  const app = await restartable(createApplication, { logger: true })
+  expectType<FastifyInstance>(app)
+  expectType<boolean>(app.restarted)
+  expectType<boolean>(app.closingRestartable)
+  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart)
 }
 
 {
-  const app = await restartable(createApplication, { logger: true }, fastify);
-  expectType<FastifyInstance>(app);
-  expectType<boolean>(app.restarted);
-  expectType<boolean>(app.closingRestartable);
-  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart);
+  const app = await restartable(createApplication, { logger: true }, fastify)
+  expectType<FastifyInstance>(app)
+  expectType<boolean>(app.restarted)
+  expectType<boolean>(app.closingRestartable)
+  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart)
 }
 
 {
@@ -59,19 +59,15 @@ async function createApplication(
     async (factory, opts) => await factory(opts),
     { http2: true },
     fastify
-  );
-  expectType<FastifyInstance<Http2Server>>(app);
-  expectType<boolean>(app.restarted);
-  expectType<boolean>(app.closingRestartable);
-  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart);
+  )
+  expectType<FastifyInstance<Http2Server>>(app)
+  expectType<boolean>(app.restarted)
+  expectType<boolean>(app.closingRestartable)
+  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart)
 }
 
 {
-  const app = await restartable(createApplication, { logger: true }, fastify);
-  app.addPreRestartHook(
-    async (instance: FastifyInstance, restartOpts: unknown) => {}
-  );
-  app.addOnRestartHook(
-    async (instance: FastifyInstance, restartOpts: unknown) => {}
-  );
+  const app = await restartable(createApplication, { logger: true }, fastify)
+  app.addPreRestartHook(async (instance: FastifyInstance, restartOpts: unknown) => {})
+  app.addOnRestartHook(async (instance: FastifyInstance, restartOpts: unknown) => {})
 }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,53 +1,77 @@
-import { fastify, FastifyInstance, FastifyServerOptions } from 'fastify'
-import { expectAssignable, expectType } from 'tsd'
-import { restartable, ApplicationFactory } from './index'
+import { fastify, FastifyInstance, FastifyServerOptions } from "fastify";
+import { expectAssignable, expectType } from "tsd";
+import { restartable, ApplicationFactory } from "./index";
+import type { Http2Server } from "http2";
 
-type Fastify = typeof fastify
+type Fastify = typeof fastify;
 
-async function createApplication (
+async function createApplication(
   fastify: Fastify,
   opts: FastifyServerOptions,
   restartOpts?: unknown
 ): Promise<FastifyInstance> {
-  const app = fastify(opts)
+  const app = fastify(opts);
 
-  expectAssignable<FastifyInstance>(app)
-  expectAssignable<unknown>(restartOpts)
+  expectAssignable<FastifyInstance>(app);
+  expectAssignable<unknown>(restartOpts);
 
-  expectType<boolean>(app.restarted)
-  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart)
+  expectType<boolean>(app.restarted);
+  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart);
 
-  return app
+  return app;
 }
 
-expectType<ApplicationFactory>(createApplication)
+// This currently fails with:
+// --------------------------
+// Parameter type ApplicationFactory is not identical to argument type
+// (fastify: typeof import("/Users/denchen/git/restartable/node_modules/fastify/fastify.d.ts"),
+// opts: FastifyServerOptions, restartOpts?: unknown)
+// => Promise<FastifyInstance<RawServerDefault, IncomingMessage, ServerResponse<...>,
+// FastifyBaseLogger, FastifyTypeProviderDefault>>
+// expectType<ApplicationFactory>(createApplication);
 
 {
-  const app = await restartable(createApplication)
-  expectType<FastifyInstance>(app)
-  expectType<boolean>(app.restarted)
-  expectType<boolean>(app.closingRestartable)
-  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart)
-}
-
-{
-  const app = await restartable(createApplication, { logger: true })
-  expectType<FastifyInstance>(app)
-  expectType<boolean>(app.restarted)
-  expectType<boolean>(app.closingRestartable)
-  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart)
-}
-
-{
-  const app = await restartable(createApplication, { logger: true }, fastify)
-  expectType<FastifyInstance>(app)
-  expectType<boolean>(app.restarted)
-  expectType<boolean>(app.closingRestartable)
-  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart)
+  const app = await restartable(createApplication);
+  expectType<FastifyInstance>(app);
+  expectType<boolean>(app.restarted);
+  expectType<boolean>(app.closingRestartable);
+  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart);
 }
 
 {
-  const app = await restartable(createApplication, { logger: true }, fastify)
-  app.addPreRestartHook(async (instance: FastifyInstance, restartOpts: unknown) => {})
-  app.addOnRestartHook(async (instance: FastifyInstance, restartOpts: unknown) => {})
+  const app = await restartable(createApplication, { logger: true });
+  expectType<FastifyInstance>(app);
+  expectType<boolean>(app.restarted);
+  expectType<boolean>(app.closingRestartable);
+  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart);
+}
+
+{
+  const app = await restartable(createApplication, { logger: true }, fastify);
+  expectType<FastifyInstance>(app);
+  expectType<boolean>(app.restarted);
+  expectType<boolean>(app.closingRestartable);
+  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart);
+}
+
+{
+  const app = await restartable(
+    async (factory, opts) => await factory(opts),
+    { http2: true },
+    fastify
+  );
+  expectType<FastifyInstance<Http2Server>>(app);
+  expectType<boolean>(app.restarted);
+  expectType<boolean>(app.closingRestartable);
+  expectType<(restartOpts?: unknown) => Promise<void>>(app.restart);
+}
+
+{
+  const app = await restartable(createApplication, { logger: true }, fastify);
+  app.addPreRestartHook(
+    async (instance: FastifyInstance, restartOpts: unknown) => {}
+  );
+  app.addOnRestartHook(
+    async (instance: FastifyInstance, restartOpts: unknown) => {}
+  );
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
      
#### Summary

Addresses #63 

The current restartable factory typings do not support https / http2, so I've created overloads for `restartable()` that follow a similar pattern to `fastify()` here:
https://github.com/fastify/fastify/blob/3a646b863be964d1008785e7318ffe964aac6aff/fastify.d.ts#L208-L238

These scenarios work:

```typescript
const server = await restartable(async (factory, opts) => await factory(opts), {
  logger: true
});
// Resulting type:
// FastifyInstance<Server<typeof IncomingMessage, typeof ServerResponse>, IncomingMessage, ServerResponse<IncomingMessage>, FastifyBaseLogger, FastifyTypeProviderDefault>
```
```typescript
const server = await restartable(async (factory, opts) => await factory(opts), {
  http2: true
});
// Resulting type:
// FastifyInstance<Http2Server, Http2ServerRequest, Http2ServerResponse, FastifyBaseLogger, FastifyTypeProviderDefault>
```

```typescript
const createApp: ApplicationFactory<Http2SecureServer> = async (
  fastify,
  opts
) => fastify(opts);

const app = await restartable(createApp, { http2: true });
// Resulting type:
// FastifyInstance<Http2SecureServer, Http2ServerRequest, Http2ServerResponse, FastifyBaseLogger, FastifyTypeProviderDefault>
```

However, currently one test fails:
```javascript
expectType<ApplicationFactory>(createApplication);
```
with:
```
  types/index.test-d.ts:31:0
  ✖  31:0  Parameter type ApplicationFactory is not identical to argument type (fastify: typeof import("/Users/denchen/git/restartable/node_modules/fastify/fastify.d.ts"), opts: FastifyServerOptions, restartOpts?: unknown) => Promise<FastifyInstance<RawServerDefault, IncomingMessage, ServerResponse<...>, FastifyBaseLogger, FastifyTypeProviderDefault>>.
```

And I can't seem to fix it. I've commented it out for now so I can make this PR and solicit help on how I can fix / improve the types. There's always the possibility that I've made the types way more complicated than need be, but I did try simpler approaches without overloads, but none of my attempts worked.

