### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,9 +14,9 @@ import type {
   RawServerBase,
   RawServerDefault,
 } from 'fastify'
-import * as http from 'http'
-import * as http2 from 'http2'
-import * as https from 'https'
+import * as http from 'node:http'
+import * as http2 from 'node:http2'
+import * as https from 'node:https'
 
 export type RestartHook = (
   instance: FastifyInstance,

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -2,7 +2,7 @@ import { fastify, FastifyInstance, FastifyServerOptions } from 'fastify'
 import { expectAssignable, expectType } from 'tsd'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- ApplicationFactory is used in commented out test
 import { restartable, ApplicationFactory } from './index'
-import type { Http2Server } from 'http2'
+import type { Http2Server } from 'node:http2'
 
 type Fastify = typeof fastify
 


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.