### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
+    "eslint": "^9.17.0",
     "neostandard": "^0.12.0",
     "split2": "^4.2.0",
     "tap": "^18.7.2",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.