### PR TITLE
test: drop undici, use a small node:http(s) helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
     "eslint": "^9.17.0",
     "neostandard": "^0.13.0",
     "split2": "^4.2.0",
-    "tstyche": "^7.0.0",
-    "undici": "^7.0.0"
+    "tstyche": "^7.0.0"
   },
   "dependencies": {
     "fastify": "^5.0.0"

--- a/test/helpers/request.js
+++ b/test/helpers/request.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const http = require('node:http')
+const https = require('node:https')
+
+// Minimal undici-compatible `request()` built on node:http / node:https.
+//
+// The HTTPS path attaches a dedicated https.Agent that trusts the
+// self-signed certificate from test/fixtures, so no global state
+// (e.g. NODE_TLS_REJECT_UNAUTHORIZED) leaks into the test process.
+function request (url, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const isHttps = url.startsWith('https://')
+    const lib = isHttps ? https : http
+
+    const finalOpts = { ...opts }
+    if (isHttps && !finalOpts.agent) {
+      finalOpts.agent = new https.Agent({ rejectUnauthorized: false })
+    }
+
+    const req = lib.request(url, finalOpts, (res) => {
+      const chunks = []
+      res.on('data', (chunk) => chunks.push(chunk))
+      res.on('end', () => {
+        const body = Buffer.concat(chunks).toString('utf8')
+        resolve({
+          statusCode: res.statusCode,
+          headers: res.headers,
+          body: {
+            json: async () => JSON.parse(body),
+            text: async () => body
+          }
+        })
+      })
+    })
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+module.exports = { request }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,17 +7,9 @@ const http2 = require('node:http2')
 
 const { afterEach, test } = require('node:test')
 const split = require('split2')
-const { request, setGlobalDispatcher, Agent } = require('undici')
+const { request } = require('./helpers/request')
 
 const { restartable } = require('..')
-
-setGlobalDispatcher(new Agent({
-  keepAliveTimeout: 1,
-  keepAliveMaxTimeout: 1,
-  tls: {
-    rejectUnauthorized: false
-  }
-}))
 
 const COMMON_PORT = 4242
 


### PR DESCRIPTION
Drops `undici` as a devDependency and replaces the test HTTP client with a small `test/helpers/request.js` wrapper around `node:http` / `node:https`. This unblocks the queued dependabot PRs (#112, #116, #118, #121, #122) that have all been failing on Node 20 because `undici@8.x` requires Node `>=22.10.0` (it uses `worker_threads.markAsUncloneable`, which landed in 22.10).